### PR TITLE
Using log debug! macro rather than custom one causes test to fail

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -25,11 +25,11 @@ macro_rules! include_wast2wasm_bytes {
 }
 
 // #[cfg(feature= "debug")]
-#[macro_export]
-macro_rules! debug {
-    ($fmt:expr) => (println!(concat!("Wasmer::", $fmt)));
-    ($fmt:expr, $($arg:tt)*) => (println!(concat!("Wasmer::", $fmt, "\n"), $($arg)*));
-}
+// #[macro_export]
+// macro_rules! debug {
+//     ($fmt:expr) => (println!(concat!("Wasmer::", $fmt)));
+//     ($fmt:expr, $($arg:tt)*) => (println!(concat!("Wasmer::", $fmt, "\n"), $($arg)*));
+// }
 
 // #[cfg(not(feature= "debug"))]
 // #[macro_export]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,8 @@ extern crate wasmparser;
 #[macro_use]
 extern crate target_lexicon;
 extern crate nix;
+#[macro_use]
+extern crate log;
 
 use std::fs::File;
 use std::io;


### PR DESCRIPTION
This is showing we have something really wrong in wasmer, or that Rust is reorganizing fields when debugging?

In either case, we should know why this is happening.